### PR TITLE
Fix MyST Markdown Syntax

### DIFF
--- a/source/introduction.md
+++ b/source/introduction.md
@@ -15,7 +15,7 @@ All `keywords` in this standard are case-sensitive.
 (s:elements.intro)=
 ## Lattice Elements
 
-The basic building block used to describe an accelerator is the lattice \vn{element}. Typically,
+The basic building block used to describe an accelerator is the lattice **element**. Typically,
 a lattice element is something physical like a bending magnet or an electrostatic
 quadrupole, or a diffracting crystal. A lattice element may define a region in space 
 distinguished by the presence of (possibly time-varying) electromagnetic fields,


### PR DESCRIPTION
The syntax `\vn{text}` does not seem to be rendered correctly in MyST markdown (see screenshot from https://pals-project.readthedocs.io/en/latest/introduction.html below). Was that maybe a custom LaTeX shortcut for bold font?

![Screenshot from 2025-03-24 14-31-45](https://github.com/user-attachments/assets/05b21aab-ff53-4dda-b084-6fdf133c5ee8)
