### PR TITLE
Simplified syntax in examples, removing `item` and `Element`.

### DIFF
--- a/source/beamlines.md
+++ b/source/beamlines.md
@@ -92,7 +92,7 @@ BeamLine:
     - kind: Quadrupole: # This item contains a Quadrupole that is reversed.
         direction: -1
           ...
-    - kind: Beamline:   # This item contains a BeamLine repeated three times    
+    - kind: BeamLine:   # This item contains a BeamLine repeated three times    
         repetition: 3
           ...
 ```

--- a/source/beamlines.md
+++ b/source/beamlines.md
@@ -35,6 +35,7 @@ element in the `line` and with this the length of the BeamLine can be calculated
 The optional `zero_point` component is used to position sublines.
 The value of `zero_point` is the name of a `line item` that marks the reference point. 
 To make things unambiguous, the reference `item` must have zero length.
+[**comment: should the previous sentence be removed?**]
 In most cases, this means that the `zero_point` cannot be a `BeamLine`.
 
 Setting optional `periodic` Boolean to `True` indicates that the `BeamLine` is something like a 
@@ -77,7 +78,7 @@ direction       # +1 or -1. Longitudinal orientation of element. Default is +1.
 placement       # Structure. Shifts element or subline longitudinally.
 ```
 
-Example:
+Example with four `items` in `line`:
 ```{code} yaml
 BeamLine:
   name: inj_line
@@ -85,16 +86,14 @@ BeamLine:
   length: 37.8
   zero_point: thingC
   line:
-    - item: thingB      # Name of an element or BeamLine defined elsewhere.
-    - item:             # Another way of specifying the name of an element or BeamLine.
+    - thingB            # This item refers to the name of an element or BeamLine defined elsewhere.
+    - Drift:            # Another way of specifying the name of an element or BeamLine as an item.
         name: thingC
-    - item:             # This item contains an Element that is reversed.
+    - Quadrupole:       # This item contains a Quadrupole that is reversed.
         direction: -1
-        Element:
           ...
-    - item:             # This item contains a BeamLine repeated three times    
+    - Beamline:         # This item contains a BeamLine repeated three times    
         repetition: 3
-        BeamLine:
           ...
 ```
 
@@ -105,17 +104,13 @@ BeamLine:
 A line item that is a lattice element can be specified by name if a lattice element
 of that name has been defined. Example:
 ```{code} yaml
-Element: 
+Quadrupole: 
   name: q1w
-  kind: Quadrupole
   ...
 
 BeamLine:
   line:
-    - item: q1w       # Line item is element q1w.
-    - item:           # Line item is element q1w the same as the previous item.
-        Element:
-            inherit: q1w
+    - q1w       # Line item is element q1w.
     ...
 ```
 
@@ -124,12 +119,10 @@ A line item which is a lattice element can also be specified by defining the lat
 ```{code} yaml
 BeamLine:
   line:
-    - item:
-        Element:
-          name: octA
-          kind: Octupole
-          Kn3L: 0.34
-          ...
+    - Octupole:
+        name: octA
+        Kn3L: 0.34
+        ...
     ...
 ```
 
@@ -138,11 +131,10 @@ be defined "in place". Example:
 ```{code} yaml
 BeamLine:
   line:
-    - item: inj_line          # Refer by name to a previously defined BeamLine
-    - item:
-        BeamLine:             # Define a subline in place
-          line:
-           ...
+    - inj_line          # Refer by name to a previously defined BeamLine
+    - BeamLine:             # Define a subline in place
+        line:
+        ...
     ...
 ```
 
@@ -159,8 +151,7 @@ of the item. Example:
 BeamLine:
   name: full_line
   line:
-    - item:
-        name: short_line
+    - short_line
         repetition: 3
 ```
 In this case, `short_line` is repeated three times when the BeamLine is expanded to form a lattice
@@ -169,9 +160,9 @@ branch. For example, if `short_line` is defined by:
 BeamLine:
   name: short_line
   line:
-    - item: A
-    - item: B
-    - item: C
+    - A
+    - B
+    - C
 ```
 then the expanded `full_line` will look like:
 ```{code} yaml
@@ -203,17 +194,15 @@ the individual line items. Example:
 BeamLine:
   name: lineA
   line:
-    - item: 
+    - lineB: 
         direction: -1
-        name: lineB
 
 BeamLine:
   name: lineB
   line:
-    - item: ele1
-    - item:
+    - ele1
+    - ele2:
         direction: -1
-        name: ele2
 ```
 The expanded `lineA` has elements:
 ```{code} yaml
@@ -273,9 +262,8 @@ Example:
 BeamLine:
   name: position_line
   line:
-    - item: thingA
-    - item:
-        name: this_line
+    - thingA
+    - this_line
         placement:
           offset: 37.5
           base_item: thingA
@@ -303,8 +291,7 @@ then the following
 ```{code} yaml
 BeamLine:
   line:
-  - item:
-      name: position_line
+  - position_line
       repetition: -1
 ```
 Would expand to
@@ -315,8 +302,7 @@ with the same relative distances between elements. Similarly, this:
 ```{code} yaml
 BeamLine:
   line:
-  - item:
-      name: position_line
+  - position_line
       direction: -1
 ```
 Would expand to
@@ -333,8 +319,8 @@ if a line contains the two zero length elements:
 ```{code} yaml
 BeamLine:
   line:
-  - item: markerA
-  - item: markerB
+  - markerA
+  - markerB
 ```
 then the order of tracking will be `markerA` followed by `markerB`.
 

--- a/source/beamlines.md
+++ b/source/beamlines.md
@@ -34,8 +34,7 @@ element in the `line` and with this the length of the BeamLine can be calculated
 
 The optional `zero_point` component is used to position sublines.
 The value of `zero_point` is the name of a `line item` that marks the reference point. 
-To make things unambiguous, the reference `item` must have zero length.
-[**comment: should the previous sentence be removed?**]
+To make things unambiguous, the reference `line item` must have zero length.
 In most cases, this means that the `zero_point` cannot be a `BeamLine`.
 
 Setting optional `periodic` Boolean to `True` indicates that the `BeamLine` is something like a 
@@ -85,14 +84,15 @@ BeamLine:
   multipass: True
   length: 37.8
   zero_point: thingC
-  line:
+  - kind: Line
+    name: line
     - thingB            # This item refers to the name of an element or BeamLine defined elsewhere.
-    - Drift:            # Another way of specifying the name of an element or BeamLine as an item.
+    - kind: Drift:      # Another way of specifying the name of an element or BeamLine as an item.
         name: thingC
-    - Quadrupole:       # This item contains a Quadrupole that is reversed.
+    - kind: Quadrupole: # This item contains a Quadrupole that is reversed.
         direction: -1
           ...
-    - Beamline:         # This item contains a BeamLine repeated three times    
+    - kind: Beamline:   # This item contains a BeamLine repeated three times    
         repetition: 3
           ...
 ```
@@ -109,7 +109,8 @@ Quadrupole:
   ...
 
 BeamLine:
-  line:
+  - kind: Line 
+    name: line
     - q1w       # Line item is element q1w.
     ...
 ```
@@ -118,8 +119,9 @@ A line item which is a lattice element can also be specified by defining the lat
 "in place" in the line. Example:
 ```{code} yaml
 BeamLine:
-  line:
-    - Octupole:
+  - kind: Line 
+    name: line
+    - kind: Octupole
         name: octA
         Kn3L: 0.34
         ...
@@ -130,10 +132,12 @@ Similarly, a line item which is a BeamLine can either be referred to by name or 
 be defined "in place". Example:
 ```{code} yaml
 BeamLine:
-  line:
+  - kind: Line 
+    name: line
     - inj_line          # Refer by name to a previously defined BeamLine
-    - BeamLine:             # Define a subline in place
-        line:
+    - kind: BeamLine    # Define a subline in place
+        - kind: Line
+          name: subline1
         ...
     ...
 ```
@@ -150,8 +154,10 @@ of the item. Example:
 ```{code} yaml
 BeamLine:
   name: full_line
-  line:
-    - short_line
+  - kind: Line 
+    name: line
+    - kind: Line
+      name: short_line
         repetition: 3
 ```
 In this case, `short_line` is repeated three times when the BeamLine is expanded to form a lattice
@@ -159,7 +165,8 @@ branch. For example, if `short_line` is defined by:
 ```{code} yaml
 BeamLine:
   name: short_line
-  line:
+  - kind: Line 
+    name: line
     - A
     - B
     - C
@@ -193,13 +200,15 @@ the individual line items. Example:
 ```{code} yaml
 BeamLine:
   name: lineA
-  line:
+  - kind: Line 
+    name: line
     - lineB: 
         direction: -1
 
 BeamLine:
   name: lineB
-  line:
+  - kind: Line 
+    name: line
     - ele1
     - ele2:
         direction: -1
@@ -261,14 +270,16 @@ Example:
 ```{code} yaml
 BeamLine:
   name: position_line
-  line:
+  - kind: Line 
+    name: line
     - thingA
-    - this_line
-        placement:
-          offset: 37.5
-          base_item: thingA
-          from_point: EXIT_END
-          to_point: ZERO_POINT
+    - kind: Line 
+      name: this_line
+      placement:
+        offset: 37.5
+        base_item: thingA
+        from_point: EXIT_END
+        to_point: ZERO_POINT
         ...
     ...
 ```
@@ -290,8 +301,9 @@ thingA, thingB, thingC
 then the following 
 ```{code} yaml
 BeamLine:
-  line:
-  - position_line
+  - kind: Line 
+    name: line
+    position_line
       repetition: -1
 ```
 Would expand to
@@ -301,8 +313,9 @@ thingC, thingB, thingA
 with the same relative distances between elements. Similarly, this:
 ```{code} yaml
 BeamLine:
-  line:
-  - position_line
+  - kind: Line 
+    name: line
+    position_line
       direction: -1
 ```
 Would expand to
@@ -318,7 +331,8 @@ elements determines the order in which they should tracked through. For example,
 if a line contains the two zero length elements:
 ```{code} yaml
 BeamLine:
-  line:
+  - kind: Line 
+    name: line
   - markerA
   - markerB
 ```

--- a/source/element-parameters.md
+++ b/source/element-parameters.md
@@ -47,7 +47,7 @@ And the above defines a new aperture group which inherits from **ap1**.
 
 Naming a parameter group is only needed if the parameter group is defined outside of an element.
 ```{code} yaml
-Element:
+Quatrupole:
   name: q1
   ApertureP: 
     x_limit: [-0.03, 0.04]
@@ -55,7 +55,7 @@ Element:
 ```
 And an element can inherit a parameter group from another element:
 ```{code} yaml
-Element:
+Quatrupole:
   name: q2
   ApertureP:
     inherit: q1.ApertureP
@@ -63,7 +63,7 @@ Element:
 
 For an element to inherit all parameter groups from another element, just inherit the element itself:
 ```{code} yaml
-Element:
+Quatrupole:
   name: q3
   inherit: q2
 ```

--- a/source/element-types.md
+++ b/source/element-types.md
@@ -5,10 +5,9 @@ Note: `name`, `length`, and `s_position` parameters stand alone and not part of 
 
 Example:
 ```{code} yaml
-Element:
+Solenoid:
   name: cleo
   length: 3.74
-  kind: Solenoid
   SolenoidP:
     Ksol: -0.15
 ```


### PR DESCRIPTION
Following the discussions during the PALS meetings, `item` and `Element` have been removed from the examples.