### PR TITLE
First Example: FODO Cell

### DIFF
--- a/examples/fodo.pals.yaml
+++ b/examples/fodo.pals.yaml
@@ -1,26 +1,21 @@
 kind: Line
 line:
-- alias_drift1:
+- drift1:
   kind: Drift
   length: 0.25
-  name: drift1
-- alias_quad1:
+- quad1:
   MagneticMultipoleP:
     Bn1: 1.0
   kind: Quadrupole
   length: 1.0
-  name: quad1
-- alias_drift2:
+- drift2:
   kind: Drift
   length: 0.5
-  name: drift2
-- alias_quad2:
+- quad2:
   MagneticMultipoleP:
     Bn1: -1.0
   kind: Quadrupole
   length: 1.0
-  name: quad2
-- alias_drift3:
+- drift3:
   kind: Drift
   length: 0.5
-  name: drift3

--- a/examples/fodo.yml
+++ b/examples/fodo.yml
@@ -1,0 +1,26 @@
+kind: Line
+line:
+- alias_drift1:
+  kind: Drift
+  length: 0.25
+  name: drift1
+- alias_quad1:
+  MagneticMultipoleP:
+    Bn1: 1.0
+  kind: Quadrupole
+  length: 1.0
+  name: quad1
+- alias_drift2:
+  kind: Drift
+  length: 0.5
+  name: drift2
+- alias_quad2:
+  MagneticMultipoleP:
+    Bn1: -1.0
+  kind: Quadrupole
+  length: 1.0
+  name: quad2
+- alias_drift3:
+  kind: Drift
+  length: 0.5
+  name: drift3


### PR DESCRIPTION
This PR adds a new directory to store PALS-conforming examples.

The first and only example we discussed so far is the FODO cell.

More examples, such as the ones curated so far (somewhere else) by @cemitch99, @jlvay, and @DavidSagan, should eventually migrate here.

The file I added should reflect the latest version we agreed on, based on https://github.com/campa-consortium/pals/discussions/52 and https://github.com/campa-consortium/pals-python/pull/12 (by @danielkallendorf).

This includes the changes requested in https://github.com/campa-consortium/pals-python/pull/12#issuecomment-2963296699, based on a suggestion by @ChristopherMayes (if I remember correctly), although the "alias" names I chose so far are somewhat arbitrary, as I don't have an example in mind of what names one would expect to want there and/or why they would be different from the "proper" names (stored as attributes of the elements).

More generally, the idea would be that the `pals-python` examples in https://github.com/campa-consortium/pals-python/tree/main/examples could/should match some/all of the YAML examples in this new `pals` directory. We may want to think about the best way to connect the two. I personally think there is value in having some examples in this repository, regardless of the specific implementation of the standard, but this is of course up for discussion as well.
