### PR TITLE
Sphinx LaTeX: Support SVG

### DIFF
--- a/conda.yaml
+++ b/conda.yaml
@@ -22,5 +22,6 @@ dependencies:
   - sphinx-copybutton
   - sphinx-design
   - sphinxcontrib-bibtex
+  - sphinxcontrib-svg2pdfconverter-with-all
   - sphinxcontrib-napoleon
 # - sphinx_rtd_theme

--- a/source/conf.py
+++ b/source/conf.py
@@ -13,7 +13,7 @@ author = 'Jean-Luc Vay, David Sagan, Chad Mitchell, Axel Huebl, David Bruhwihler
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-extensions = ['myst_parser', 'sphinx_design', 'sphinxcontrib.bibtex']
+extensions = ['myst_parser', 'sphinx_design', 'sphinxcontrib.bibtex', 'sphinxcontrib.inkscapeconverter']
 myst_enable_extensions = ["colon_fence", "amsmath"]
 numfig = True
 


### PR DESCRIPTION
The readthedocs builder is set right now to automatically build PDFs via LaTeX. LaTeX does not support SVGs directly, but other vector formats like PDF. There is a sphinx plugin that can [auto-convert SVGs to PDFs](https://github.com/missinglinkelectronics/sphinxcontrib-svg2pdfconverter) (or [rasterized images](https://www.sphinx-doc.org/en/master/usage/extensions/imgconverter.html#module-sphinx.ext.imgconverter)) via, e.g., Inkscape. Trying to use that now.

For source code / repo purposes, SVGs are superior to PDFs, so we do not want to change our source images (in git).