### PR TITLE
Sphinx: Copybutton

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -13,7 +13,7 @@ author = 'Jean-Luc Vay, David Sagan, Chad Mitchell, Axel Huebl, David Bruhwihler
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-extensions = ['myst_parser', 'sphinx_design', 'sphinxcontrib.bibtex', 'sphinxcontrib.cairosvgconverter']
+extensions = ['myst_parser', 'sphinx_design', 'sphinxcontrib.bibtex', 'sphinxcontrib.cairosvgconverter', 'sphinx_copybutton']
 myst_enable_extensions = ["colon_fence", "amsmath"]
 numfig = True
 


### PR DESCRIPTION
Enable the `sphinx_copybutton` extension, so readers can copy the individual verbatim code blocks (more usable).

(We already have the extension installed, just forgot to turn it on.)

## Before

<img width="1644" height="639" alt="image" src="https://github.com/user-attachments/assets/90068092-7609-4023-aaec-edb5e9163d41" />

## After

<img width="1644" height="639" alt="image" src="https://github.com/user-attachments/assets/c947c46e-7572-48ea-bbb6-e0e3d46ae4f3" />
(Note the new copy button on the right of the code block)