### PR TITLE
Improve Element Docs (Units & Formatting)

### DIFF
--- a/source/element-kinds.md
+++ b/source/element-kinds.md
@@ -5,8 +5,8 @@ Note: `name`, `length`, and `s_position` parameters stand alone and not part of 
 
 Example:
 ```{code} yaml
-Solenoid:
-  name: cleo
+cleo:             # [string] user-defined name
+  kind: Solenoid  # [string] element kind
   length: 3.74
   SolenoidP:
     Ksol: -0.15

--- a/source/lattice-construction.md
+++ b/source/lattice-construction.md
@@ -137,7 +137,7 @@ The components of the `ForkP` group are:
   to_element            # Optional String: Element to fork to. Default is Beginning.
   direction             # Optional Switch: Longitudinal Direction of travel of injected beam.
   branch_name           # Optional String: Name to give created Branch.
-  propagate_reference   # Optional Boolian: Propagate reference species and energy? Default is False.
+  propagate_reference   # Optional Boolean: Propagate reference species and energy? Default is False.
 ```
 The possible values of the optional `direction` switch are:
 ```{code} yaml

--- a/source/parameters/aperture.md
+++ b/source/parameters/aperture.md
@@ -2,28 +2,30 @@
 ## ApertureP: Aperture Parameters
 
 The `ApertureP` parameter group contains parameters for describing an aperture. 
-The components of this group are:
+The components of this group and their defaults are:
 ```{code} yaml
-x_limits                     # [m] Vector of two real numbers
-y_limits                     # [m] Vector of two real numbers
-shape                        # Switch
-location                     # Switch
-aperture_shifts_with_body    # Boolian
-vertices                     # Structure
-material                     # String
-thickness                    # [m] Real number
+refp1:                            # [string] user-defined name
+  kind: ApertureP
+  x_limits: 0                     # [m] Vector of two real numbers
+  y_limits: 0                     # [m] Vector of two real numbers
+  shape: ""                       # [string] Aperture shape switch
+  location: "ENTRANCE_END"        # [string] Aperture location switch
+  aperture_shifts_with_body: ...  # [Boolean] ... TODO: describe ... TODO: default
+  vertices: {}                    # [Dictionary] ... TODO: describe ...
+  material: ""                    # [string] Material of the Aperture
+  thickness: 0                    # [m] Real number
 ```
 
 ### Location component
 
 The aperture location is set by the `location` parameter. Possible values are
 ```{code} yaml
-ENTRANCE_END   # Body entrance end (default)
-CENTER         # Element center
-EXIT_END       # Body exit end
-BOTH_ENDS      # Both ends
-NOWHERE        # No location
-EVERYWHERE     # Everywhere
+  location: ENTRANCE_END   # Body entrance end (default)
+  location: CENTER         # Element center
+  location: EXIT_END       # Body exit end
+  location: BOTH_ENDS      # Both ends
+  location: NOWHERE        # No location
+  location: EVERYWHERE     # Everywhere
 ```
 The default is `ENTRANCE_END`.
 
@@ -40,10 +42,10 @@ by a set of vertices.
 
 The `shape` parameter selects the shape of the aperture. Possible values are:
 ```{code} yaml
-RECTANGULAR   # Rectangular shape.
-ELLIPTICAL    # Elliptical shape.
-VERTICES      # Shape defined by set of vertices.
-CUSTOM_SHAPE  # Shape defined outside of the lattice standard.
+  shape: RECTANGULAR   # Rectangular shape.
+  shape: ELLIPTICAL    # Elliptical shape.
+  shape: VERTICES      # Shape defined by set of vertices.
+  shape: CUSTOM_SHAPE  # Shape defined outside of the lattice standard.
 ```
 
 ### x_limit and y_limit components
@@ -111,9 +113,10 @@ Between vertex points, the aperture can follow a straight line or the arc of an 
 The vertex points are specified by setting the `vertices` parameter. This parameter has three
 subcomponents
 ```{code} yaml
-center              # [m] Vector of [x, y] center point.
-absolute_vertices   # Boolian. Default is False.
-list                # Struct. Ordered list of vertex points.
+  verticies:
+    center: 0                 # [m] Vector of (x, y) center point.
+    absolute_vertices: false  # [Boolean] Default is False.
+    list: [{}]                # [List of dictionaries] Ordered list of vertex points.
 ```
 The `list` vector can have the components:
 ```{code} yaml

--- a/source/parameters/bend.md
+++ b/source/parameters/bend.md
@@ -5,22 +5,23 @@ The `BendP` group stores the parameters that characterize the shape of a [`Bend`
 The only relevant shape parameter that is not in the `BendP` is the
 length `length` parameter.
 
-The parameters of this group are:
 ```{code} yaml
-angle             # Reference bend angle.
-bend_field_ref    # Reference bend field.
-e1                # Entrance end pole face rotation with respect to a sector geometry.
-e2                # Exit end pole face rotation with respect to a sector geometry.
-e1_rect           # Entrance end pole face rotation with respect to a rectangular geometry.
-e2_rect           # Exit end pole face rotation with respect to a rectangular geometry.
-edge_int1         # Entrance end fringe field integral.
-edge_int2         # Exit end fringe field integral
-g                 # Reference bend strength = 1/radius.
-h1                # Entrance end pole face curvature.
-h2                # Exit end pole face curvature.
-L_chord           # Chord length.
-L_sagitta         # Sagitta length (output parameter).
-tilt_ref          # Reference tilt.
+fork1:               # [string] user-defined name
+  kind: BendP
+  angle              # [degree] Reference bend angle
+  bend_field_ref: 0  # [T] Reference bend field
+  e1: 0              # [degree] Entrance end pole face rotation with respect to a sector geometry
+  e2: 0              # [degree] Exit end pole face rotation with respect to a sector geometry
+  e1_rect: 0         # [degree] Entrance end pole face rotation with respect to a rectangular geometry
+  e2_rect: 0         # [degree] Exit end pole face rotation with respect to a rectangular geometry
+  edge_int1: 0       # [T*m] Entrance end fringe field integral
+  edge_int2: 0       # [T*m] Exit end fringe field integral
+  g: 0               # [1/m] Reference bend strength = 1/radius
+  h1: 0              # [TODO] Entrance end pole face curvature
+  h2: 0              # [TODO] Exit end pole face curvature
+  L_chord: 0         # [m] Chord length
+  L_sagitta: 0       # [m] Sagitta length (output parameter)  TODO ??? output parameter??
+  tilt_ref: 0        # [degree] Reference tilt
 ```
 
 ```{figure} figures/bend.svg

--- a/source/parameters/bodyshift.md
+++ b/source/parameters/bodyshift.md
@@ -5,13 +5,15 @@ Parameters describing where the physical element is with respect to its nominal 
 This parameters group can be used to simulate positional errors. See section [](#s:lab.body.transform)
 for documentation on the body shift transformation.
 
-The parameters of this group are:
+The components of this group and their defaults are:
 ```{code} yaml
-  x_offset    # Offset along x-axis.
-  y_offset    # Offset along y-axis.
-  z_offset    # Offset along z-axis.
-  x_rot       # Rotation around x-axis.
-  y_rot       # Rotation around y-axis.
-  z_rot       # Rotation around z-axis.
+fork1:              # [string] user-defined name
+  kind: BodyShiftP
+  x_offset: 0       # [m] Offset along x-axis
+  y_offset: 0       # [m] Offset along y-axis
+  z_offset: 0       # [m] Offset along z-axis
+  x_rot: 0          # [degrees] Rotation around x-axis
+  y_rot: 0          # [degrees] Rotation around y-axis
+  z_rot: 0          # [degrees] Rotation around z-axis
 ```
 

--- a/source/parameters/electricmultipole.md
+++ b/source/parameters/electricmultipole.md
@@ -22,22 +22,25 @@ to represent rotational errors.
 
 The components of `ElectricMultipoleP` for specifying a multipolar field of order `N` is:
 ```{code} yaml
-tiltN     # Tilt
-EnN       # Normal component 
-EsN       # Skew component
+emp1:                       # [string] user-defined name
+  kind: ElectricMultipoleP
+  tiltN: 0                  # [unitles] Tilt
+  EnN: 0                    # [unitles] Normal component 
+  EsN: 0                    # [unitles] Skew component
 ```
 
 The field and normalized values can be given in terms of the integrated strength.
 Integrated values are specified with the letter 
 `length` appended at the end of the name. Example:
 ```{code} yaml
-ElectricMultipoleP:
-  tilt7: 0.7        # Tilt of 7th order multiple
-  En3: 27.3         # Normal multipole component of order 3.
-  En3L: 3.47e1      # length integrated normal multipole component of order 3.
+emp1:
+  kind: ElectricMultipoleP
+  tilt7: 0.7        # [unitles] Tilt of 7th order multiple
+  En3: 27.3         # [unitles] Normal multipole component of order 3
+  En3L: 3.47e1      # [unitles] length integrated normal multipole component of order 3
 ```
 The length integrated values are related to the non-integrated values via
-```{code} yaml
+```{code} math
   (EnL, EsL) = length * (En, Es)
 ```
 where `length` is the length of the element.
@@ -52,11 +55,11 @@ complicated by the curvilinear coordinate system.
 The `geometry` component switch can be used to specify how to calculate the multipole fields. 
 Possible settings for this component are:
 ```{code} yaml
-vertically_pure
-horizontally_pure
-entrance_tangent
-exit_tangent
-chord_tangent
+  geometry: vertically_pure    # [string] TODO: description
+  geometry: horizontally_pure  # [string] TODO: description
+  geometry: entrance_tangent   # [string] TODO: description
+  geometry: exit_tangent       # [string] TODO: description
+  geometry: chord_tangent      # [string] TODO: description
 ```
 The `entrance_tangent` setting is used when the [reference curve](#s:coords) for the 
 multipole coordinate system is the straight line tangent to the entrance coordinates of the bend. 

--- a/source/parameters/fork.md
+++ b/source/parameters/fork.md
@@ -3,17 +3,19 @@
 ## ForkP: Fork Parameters
 
 The `ForkP` parameter group holds parameters for a `Fork` element.
-The components of this group are:
+The components of this group and their defaults are:
 ```{code} yaml
-  to_line               # String: Beam line to fork to
-  to_ele                # String: Element forked to.
-  direction             # Switch: Longitudinal Direction of travel of injected beam.
-  propagate_reference   # Boolian: Propagate reference species and energy?
+fork1:                      # [string] user-defined name
+  kind: ForkP
+  to_line: ""               # [string] Beam line to fork to
+  to_ele: ""                # [string] Element forked to.
+  direction: FORWARDS       # [string] Switch: Longitudinal Direction of travel of injected beam.
+  propagate_reference: ...  # [Boolean] Propagate reference species and energy?  ... TODO: description, default ...
 ```
 The possible values of the optional `direction` switch are:
 ```{code} yaml
-FORWARDS            # Injected particle propagates in forward direction. Default.
-BACKWARDS           # Injected particle propagates in reverse direction.
+  direction: FORWARDS   # Injected particle propagates in forward direction. Default.
+  direction: BACKWARDS  # Injected particle propagates in reverse direction.
 ```
 
 See the [](#s:forking) chapter for more details.

--- a/source/parameters/meta.md
+++ b/source/parameters/meta.md
@@ -4,10 +4,11 @@
 
 `MetaP` has four standard components
 ```{code} yaml
-  alias         # String
-  ID            # String
-  label         # String
-  description   # String
+MetaP:
+  alias: ""         # [string] alternate name, use like a hashtag (not an alias for name attribute)
+  ID: ""            # [string] ... TODO: describe ...
+  label: ""         # [string] ... TODO: describe ...
+  description: ""   # [string] ... TODO: describe ...
 ```
 In addition to an element's name, these strings can be used for pattern matching
 when trying to locate all elements of a given type.
@@ -22,12 +23,14 @@ structures. The information contained in `MetaP` should be restricted to informa
 does not affect simulations. Custom, program specific information should be stored elsewhere.
 Example:
 ```{code} yaml
-Metap:
-  ID: 0137-85
-  history:                  # Custom information
-    - manufacture: 2017-03-07
-    - installed: 2018-01-23
-    - ...     
+quad1:                  # [string] user-defined name
+  kind: Quadrupole      # [string] element kind
+  MetaP:
+    ID: 0137-85
+    history:            # Custom information
+      - manufacture: 2017-03-07
+      - installed: 2018-01-23
+      - ...
 ```
 
 

--- a/source/parameters/reference.md
+++ b/source/parameters/reference.md
@@ -2,24 +2,26 @@
 (s:ref.params)=
 ## ReferenceP: Reference Parameters
 
-In Construction...
-
 The `ReferenceP` parameter group contains parameters for describing the reference energy,
 species, and time. 
-The components of this group are:
+The components of this group and their defaults are:
 ```{code} yaml
-species_ref          # Reference species.
-pc_ref               # Reference momentum*c.
-E_tot_ref            # Reference total energy.
-time_ref             # Reference time.
-location             # Where reference parameters are evaluated.
+refp1:              # [string] user-defined name
+  kind: ReferenceP
+  species_ref: ""   # [string] Reference species
+  pc_ref: 0         # [momentum*c] Reference momentum times speed of light
+  E_tot_ref: 0      # [eV] Reference total energy
+  time_ref: 0       # [s] Reference time
+  location: ""      # [string] Where reference parameters are evaluated
 ```
 
 The `location` component records where the reference parameters are evaluated at.
 Possible values are
 ```{code} yaml
-UPSTREAM_END    # Upstream end of the element.
-DOWNSTREAM_END  # Downstream end of the element.
+  location: UPSTREAM_END    # Upstream end of the element
+and
+```{code} yaml
+  location: DOWNSTREAM_END  # Downstream end of the element
 ```
 Except for `time_ref`, the reference parameters are generally the same at the
 upstream and downstream ends of the element. However, there are exceptions.

--- a/source/parameters/rf.md
+++ b/source/parameters/rf.md
@@ -2,16 +2,18 @@
 (s:rf.params)=
 ## RFP: RF Parameters
 
-The components of this group are:
+The components of this group and their defaults are:
 ```{code} yaml
-frequency         # RF frequency.
-harmon            # RF frequency harmonic number.
-voltage           # RF voltage.
-gradient          # RF gradient.
-phase             # RF phase.
-multipass_phase   # RF Phase added to multipass elements.
-cavity_type       # Cavity type. Default is STANDING_WAVE.
-n_cell            # Number of cavity cells. Default is 1.
+sol1:                           # [string] user-defined name
+  kind: Solenoid
+  frequency: 0                  # [Hz] RF frequency
+  harmon: 0                     # [unitless] RF frequency harmonic number
+  voltage: 0                    # [V] RF voltage
+  gradient: 0                   # [V/m] RF gradient
+  phase: 0                      # [unitless] RF phase in 0 to 2*pi
+  multipass_phase: 0            # [unitless] RF Phase added to multipass elements
+  cavity_type: STANDING_WAVE    # [string] Cavity type
+  n_cell: 1                     # [unitles] Number of cavity cells
 ```
 
 Whether `voltage` or `gradient` is kept constant with length changes is determined by


### PR DESCRIPTION
Add more consistently:
- units
- default
- doc strings

and a copy-pastable formatting to all defined elements so far.

Address #70